### PR TITLE
Provide "hass" to ServiceCall

### DIFF
--- a/custom_components/retry/__init__.py
+++ b/custom_components/retry/__init__.py
@@ -251,13 +251,16 @@ class RetryParams:
                 for entity in (entity_comp.entities if entity_comp else [])
             ]
         entity_ids = []
+        params = {
+            "domain": self.retry_data[ATTR_DOMAIN],
+            "service": self.retry_data[ATTR_SERVICE],
+            "data": self.inner_data,
+        }
+        if "hass" in ServiceCall.__slots__:
+            params["hass"] = hass
         entities = async_extract_referenced_entity_ids(
             hass,
-            ServiceCall(
-                self.retry_data[ATTR_DOMAIN],
-                self.retry_data[ATTR_SERVICE],
-                self.inner_data,
-            ),
+            ServiceCall(**params),
         )
         for entity_id in entities.referenced | entities.indirectly_referenced:
             entity_ids.extend(self._expand_group(hass, entity_id))


### PR DESCRIPTION
HA 2025.1 broke backward compatibility of `ServiceCall` by requiring `hass` in the `__init__` function. This was done by [this PR](https://github.com/home-assistant/core/pull/133062).
Adding the logic to provide `hass` if `ServiceCall` supports it.